### PR TITLE
docs: Increase font size and line spacing

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -60,7 +60,7 @@ $phone-width: $tablet-width - $nav-width !default; // min width before reverting
 ////////////////////
 %default-font {
   font-family: "Helvetica Neue", Helvetica, Arial, "Microsoft Yahei","微软雅黑", STXihei, "华文细黑", sans-serif;
-  font-size: 13px;
+  font-size: 14px;
 }
 
 %header-font {
@@ -70,7 +70,7 @@ $phone-width: $tablet-width - $nav-width !default; // min width before reverting
 
 %code-font {
   font-family: Consolas, Menlo, Monaco, "Lucida Console", "Liberation Mono", "DejaVu Sans Mono", "Bitstream Vera Sans Mono", "Courier New", monospace, serif;
-  font-size: 12px;
+  font-size: 13px;
   line-height: 1.5;
 }
 

--- a/source/stylesheets/print.css.scss
+++ b/source/stylesheets/print.css.scss
@@ -37,7 +37,7 @@ body {
 }
 
 .content {
-  font-size: 12px;
+  font-size: 13px;
 
   pre, code {
     @extend %code-font;

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -389,7 +389,7 @@ html, body {
   }
 
   p, li, dt, dd {
-    line-height: 1.6;
+    line-height: 1.8;
     margin-top: 0;
   }
 
@@ -417,7 +417,7 @@ html, body {
     margin-top: 1.5em;
     margin-bottom: 1.5em;
     background: $aside-notice-bg;
-    line-height: 1.6;
+    line-height: 1.8;
 
     &.warning {
       background-color: $aside-warning-bg;


### PR DESCRIPTION
This commit increases the font size and line spacing of the
main text. It does not change the size of the table of
contents or the headings.

This is only intended to be an incremental fix to docs
readability; in the long-run, they should be re-styled
for consistency with the main website.

cc @luise 