### PR TITLE
Update notice color and text shadow

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -33,7 +33,7 @@ $code-annotation-bg: #1c1c1c !default;
 $nav-subitem-bg: $med-purple !default;
 $nav-active-bg: $dark-purple !default;
 $main-bg: #ffffff !default;
-$aside-notice-bg: #8fbcd4 !default;
+$aside-notice-bg: #4e598c !default;
 $aside-warning-bg: #c97a7e !default;
 $aside-success-bg: #6ac174 !default;
 $search-notice-bg: #c97a7e !default;

--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -84,7 +84,6 @@ $phone-width: $tablet-width - $nav-width !default; // min width before reverting
 $nav-footer-border-color: #666 !default;
 $nav-embossed-border-top: #000 !default;
 $nav-embossed-border-bottom: #939393 !default;
-$main-embossed-text-shadow: 0px 1px 0px #fff !default;
 $search-box-border-color: #666 !default;
 
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -281,7 +281,6 @@ html, body {
     padding: 0 $main-padding;
     box-sizing: border-box;
     display: block;
-    text-shadow: $main-embossed-text-shadow;
 
     @extend %left-col;
   }
@@ -424,7 +423,6 @@ html, body {
   aside {
     padding-top: 1em;
     padding-bottom: 1em;
-    text-shadow: 0 1px 0 lighten($aside-notice-bg, 15%);
     margin-top: 1.5em;
     margin-bottom: 1.5em;
     background: $aside-notice-bg;
@@ -432,12 +430,10 @@ html, body {
 
     &.warning {
       background-color: $aside-warning-bg;
-      text-shadow: 0 1px 0 lighten($aside-warning-bg, 15%);
     }
 
     &.success {
       background-color: $aside-success-bg;
-      text-shadow: 0 1px 0 lighten($aside-success-bg, 15%);
     }
 
     &.notice {
@@ -468,7 +464,6 @@ html, body {
     margin: -2px;
     border-radius: 4px;
     border: 1px solid #F7E633;
-    text-shadow: 1px 1px 0 #666;
     background: linear-gradient(to top left, #F7E633 0%, #F1D32F 100%);
   }
 }

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -439,6 +439,10 @@ html, body {
       background-color: $aside-success-bg;
       text-shadow: 0 1px 0 lighten($aside-success-bg, 15%);
     }
+
+    &.notice {
+      color: #ffffff;
+    }
   }
 
   aside:before {

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -387,7 +387,7 @@ html, body {
   }
 
   a:hover {
-    color: $light-purple;
+    color: #859900;
   }
 
   dt {


### PR DESCRIPTION
The notice box now looks like this:

<img width="1430" alt="screenshot 2017-07-30 12 02 02" src="https://user-images.githubusercontent.com/10263364/28756219-fa4a3928-751e-11e7-84f8-a43e611e34ea.png">
