### PR TITLE
style: Make links in notice boxes white

### DIFF
--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -435,6 +435,10 @@ html, body {
 
     &.notice {
       color: #ffffff;
+
+      a {
+        color: #ffffff;
+      }
     }
   }
 


### PR DESCRIPTION
The notice box and default link colors are two similar shades of purple.
To make the links inside notice boxes more readable, the links are now
white. This is the same color as the other text in the box, but links
are underlined and thus still visibly clickable.