### PR TITLE
signatures: Add delimiters between function signatures

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -26,6 +26,9 @@ under the License.
     </style>
     <%= stylesheet_link_tag :screen, media: :screen %>
     <%= stylesheet_link_tag :print, media: :print %>
+    <% current_page.data.stylesheets && current_page.data.stylesheets.each do |stylesheet| %>
+      <link href="<%= stylesheet %>" rel="stylesheet" media="all" />
+    <% end %>
     <% if current_page.data.search %>
       <%= javascript_include_tag  "all" %>
     <% else %>


### PR DESCRIPTION
This commit adds a line and some extra whitespace between each function
signature, to help readability.